### PR TITLE
xennigan-shell: allow dots in domU hostname

### DIFF
--- a/xennigan-shell.cxx
+++ b/xennigan-shell.cxx
@@ -22,7 +22,7 @@
 
 namespace po = boost::program_options;
 
-const boost::regex dom_name_regex("[a-zA-Z0-9\\-]+");
+const boost::regex dom_name_regex("[a-zA-Z0-9\\-.]+");
 
 class Xennigan
 {


### PR DESCRIPTION
Our hostnames have dots in them. This patch adds support for dots in domU hostnames.

Word of warning: not sure what happens when `..` is part of the filename (and is, for example, followed by a `/`). I suppose this does no harm, because directory separators (`/`) are not included in the regular expression.
